### PR TITLE
fix: change GET param 'stash_key' sanitizing

### DIFF
--- a/airpress.php
+++ b/airpress.php
@@ -109,7 +109,7 @@ function airpress_get_current_record(){
 function airpress_execute_deferred_queries() {
 	global $airpress;
 
-	$airpress->run_deferred_queries(sanitize_title($_GET["stash_key"]));
+	$airpress->run_deferred_queries(filter_input(INPUT_GET, 'stash_key', FILTER_SANITIZE_SPECIAL_CHARS));
 
 	wp_send_json_success(array());
 }


### PR DESCRIPTION
Change the sanitize method of GET['stash_key'] because the param contains periods which where being replaced by dashes by the sanitize_title() function. It caused some php warnings.